### PR TITLE
bug NoSuchMethodError getPluginsFolder() + update to 1.21 was fixed.

### DIFF
--- a/src/main/kotlin/su/plo/voice/discs/AddonConfig.kt
+++ b/src/main/kotlin/su/plo/voice/discs/AddonConfig.kt
@@ -172,6 +172,6 @@ class AddonConfig {
         )
 
         private fun getAddonFolder(): File =
-            File(Bukkit.getPluginsFolder(), "pv-addon-discs")
+            Bukkit.getPluginManager().getPlugin("pv-addon-discs")!!.getDataFolder()
     }
 }


### PR DESCRIPTION
 fix java.lang.NoSuchMethodError: 'java.io.File org.bukkit.Bukkit.getPluginsFolder()'