### PR TITLE
fix: stop audio when player ejects and inserts disc on same tick

### DIFF
--- a/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
+++ b/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
@@ -117,11 +117,7 @@ class JukeboxEventListener : Listener, PluginKoinComponent {
 
         val block = event.clickedBlock ?: return
 
-        val jukebox = block.asJukebox()?: return
-
-        jukebox.takeIf { it.isPlaying } ?: return
-
-        jukebox.stopPlaying()
+        block.asJukebox()?.takeIf { it.isPlaying } ?: return
 
         jobByBlock.remove(block)?.cancel()
     }

--- a/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
+++ b/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
@@ -252,7 +252,8 @@ class JukeboxEventListener : Listener, PluginKoinComponent {
 
                 plugin.suspendSync(block.location) {
                     val jukebox = block.asJukebox() ?: return@suspendSync
-                    job.takeIf { !it.isCancelled } ?: return@suspendSync
+                    val currentJob = jobByBlock[block] ?: return@suspendSync
+                    if (currentJob != this@launch) return@suspendSync
                     jukebox.stopPlayingWithUpdate()
                     jobByBlock.remove(block)
                 }

--- a/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
+++ b/core/src/main/kotlin/su/plo/voice/discs/event/JukeboxEventListener.kt
@@ -22,7 +22,6 @@ import org.bukkit.event.world.ChunkLoadEvent
 import org.bukkit.event.world.ChunkUnloadEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.java.JavaPlugin
-import org.koin.core.component.get
 import org.koin.core.component.inject
 import su.plo.slib.api.chat.component.McTextComponent
 import su.plo.slib.api.chat.style.McTextStyle
@@ -118,7 +117,11 @@ class JukeboxEventListener : Listener, PluginKoinComponent {
 
         val block = event.clickedBlock ?: return
 
-        block.asJukebox()?.takeIf { it.isPlaying } ?: return
+        val jukebox = block.asJukebox()?: return
+
+        jukebox.takeIf { it.isPlaying } ?: return
+
+        jukebox.stopPlaying()
 
         jobByBlock.remove(block)?.cancel()
     }
@@ -249,6 +252,7 @@ class JukeboxEventListener : Listener, PluginKoinComponent {
 
                 plugin.suspendSync(block.location) {
                     val jukebox = block.asJukebox() ?: return@suspendSync
+                    job.takeIf { !it.isCancelled } ?: return@suspendSync
                     jukebox.stopPlayingWithUpdate()
                     jobByBlock.remove(block)
                 }


### PR DESCRIPTION
Players ejecting and inserting a disc into a jukebox on the same tick would make the audio from the inserted disc impossible to be stopped. It happened, because ejecting the disc would cause the same behavior as when the disc stops playing and remove the job from the `jobByBlock` map.

I fixed it by checking for if job `isCancelled` before removing the job from the `jobByBlock` map. Idk if there's any better way of checking if the audio has reached the end or not.